### PR TITLE
Add function_association feature under default_cache_behavior.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ A basic terraform module that stands up an AWS Cloudfront-based website backed b
 
 **www_dir** - The local file path to your website content. Creates S3 objects for each file present in this directory. Based on the [dir](https://registry.terraform.io/modules/hashicorp/dir/template/latest) module.
 
+**default_cache_func_assoc** - A list of maps containing a function association, in case you need to assign functions to your CDN origin requests.
+
 ## Example Usage
 
 ``` main.tf
@@ -43,3 +45,5 @@ module "site" {
   www_dir      = "../www"
 }
 ```
+
+Another example can be found in my `myblog` repository, under `infra`.

--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -47,6 +47,14 @@ resource "aws_cloudfront_distribution" "s3_website" {
 
     viewer_protocol_policy = "redirect-to-https"
     compress               = true
+
+    dynamic "function_association" {
+      for_each = local.cache_func
+      content {
+        event_type   = function_association.value["event_type"]
+        function_arn = function_association.value["function_arn"]
+      }
+    }
   }
 
   price_class = local.price_class

--- a/main.tf
+++ b/main.tf
@@ -9,5 +9,6 @@ locals {
   error_object = var.error_object
   price_class  = var.price_class
   www_dir      = var.www_dir
+  cache_func   = var.default_cache_func_assoc
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -36,3 +36,11 @@ variable "www_dir" {
   type        = string
   default     = "/dev/null"
 }
+
+variable "default_cache_func_assoc" {
+  type = list(object({
+    event_type   = string
+    function_arn = string
+  }))
+  default = []
+}


### PR DESCRIPTION
Allows adding a function to your CDN origin requests.

Use case:
I ran into an issue recently with the blog site that I host based on this module, where the paths navigated to don't have `.html` appended. It's fine when browsing the site using the site's own links, but if you want to share a link to a page, that link won't work (since the object technically doesn't exist on the backend, without getting too into the weeds of it).